### PR TITLE
Add support for multiple AWS regions

### DIFF
--- a/config/prod.yml
+++ b/config/prod.yml
@@ -1,8 +1,14 @@
 --- 
   aws:
-    enabled:
+    regions:
+      - us-east-1
+      - us-west-2
+      - ap-northeast-1
+      - eu-west-1
+
+    enabled_reports:
       - ec2
-      - rds
+      - rds  
 
   google_sheets:
     sheet_name: Reserved Instances Analyzer

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,8 +1,14 @@
 --- 
   aws:
-    enabled:
+    regions:
+      - us-east-1
+      - us-west-2
+      - ap-northeast-1
+      - eu-west-1
+
+    enabled_reports:
       - ec2
-      - rds
+      - rds  
 
   google_sheets:
     sheet_name: Reserved Instances Analyzer

--- a/exporter/aws.py
+++ b/exporter/aws.py
@@ -1,15 +1,18 @@
+import os
+
 import boto3
 
 
-EC2_CLIENT = boto3.client("ec2")
-RDS_CLIENT = boto3.client("rds")
+DEFAULT_REGION = os.environ.get("DEFAULT_REGION", "us-east-1")
 
 
-def get_my_reservations():
-    ec2_reservations = EC2_CLIENT.describe_reserved_instances()[
+def get_my_reservations(aws_region):
+    ec2_client = boto3.client("ec2", aws_region)
+    rds_client = boto3.client("rds", aws_region)
+    ec2_reservations = ec2_client.describe_reserved_instances()[
         "ReservedInstances"
     ]
-    rds_reservations = RDS_CLIENT.describe_reserved_db_instances()[
+    rds_reservations = rds_client.describe_reserved_db_instances()[
         "ReservedDBInstances"
     ]
     return {
@@ -18,11 +21,13 @@ def get_my_reservations():
     }
 
 
-def get_reservation_offerings():
-    ec2_reservation_offerings = EC2_CLIENT.describe_reserved_instances_offerings()[
+def get_reservation_offerings(aws_region):
+    ec2_client = boto3.client("ec2", aws_region)
+    rds_client = boto3.client("rds", aws_region)
+    ec2_reservation_offerings = ec2_client.describe_reserved_instances_offerings()[
         "ReservedInstancesOfferings"
     ]
-    rds_reservation_offerings = RDS_CLIENT.describe_reserved_db_instances_offerings()[
+    rds_reservation_offerings = rds_client.describe_reserved_db_instances_offerings()[
         "ReservedDBInstancesOfferings"
     ]
     return {
@@ -31,8 +36,8 @@ def get_reservation_offerings():
     }
 
 
-def get_my_reservation_data():
+def get_my_reservation_data(aws_region=DEFAULT_REGION):
     return {
-        "my_reservations": get_my_reservations(),
-        "reservation_offerings": get_reservation_offerings(),
+        "my_reservations": get_my_reservations(aws_region),
+        "reservation_offerings": get_reservation_offerings(aws_region),
     }

--- a/exporter/config.yml
+++ b/exporter/config.yml
@@ -1,6 +1,12 @@
 --- 
   aws:
-    enabled:
+    regions:
+      - us-east-1
+      - us-west-2
+      - ap-northeast-1
+      - eu-west-1
+
+    enabled_reports:
       - ec2
       - rds
 

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -26,7 +26,14 @@ def process_aws_data(reservation_data):
     sheets = []
     for aws_service in services_enabled:
         for data_type in data_enabled:
-            headers = None
+            headers = ["AwsRegion"]
+            headers.extend(
+                list(
+                    reservation_data[list(reservation_data.keys())[0]][
+                        data_type
+                    ][aws_service][0].keys()
+                )
+            )
             rows = []
             for aws_region in reservation_data:
                 print(
@@ -40,14 +47,6 @@ def process_aws_data(reservation_data):
                 for aws_data in reservation_data[aws_region][data_type][
                     aws_service
                 ]:
-                    headers = ["AwsRegion"]
-                    headers.extend(
-                        list(
-                            reservation_data[aws_region][data_type][
-                                aws_service
-                            ][0].keys()
-                        )
-                    )
                     row = []
                     for header in headers:
                         if header == "AwsRegion":

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -17,55 +17,83 @@ from gsheets import (
 )
 
 
-def process_aws_data(**kwargs):
-    print("Processing AWS data of type {}..".format(kwargs["type"]))
+def process_aws_data(reservation_data):
+    first_region = list(reservation_data.keys())[0]
+    data_enabled = list(reservation_data[first_region].keys())
+    services_enabled = list(
+        reservation_data[first_region][data_enabled[0]].keys()
+    )
     sheets = []
-    for aws_service in kwargs["raw_data"]:
-        print("Processing {} data..".format(aws_service))
-        rows = []
-        headers = None
-        for aws_data in kwargs["raw_data"][aws_service]:
-            headers = list(kwargs["raw_data"][aws_service][0].keys())
-            row = []
-            for header in headers:
-                if header not in aws_data:
-                    row.append("")
-                elif isinstance(
-                    aws_data[header], datetime.datetime
-                ):  # Google Sheets-friendly dates
-                    row.append(
-                        convert_to_gsheets_friendly_date(aws_data[header])
+    for aws_service in services_enabled:
+        for data_type in data_enabled:
+            headers = None
+            rows = []
+            for aws_region in reservation_data:
+                print(
+                    "Processing data for {aws_region} "
+                    "{data_type} {aws_service}..".format(
+                        aws_region=aws_region,
+                        data_type=data_type,
+                        aws_service=aws_service,
                     )
-                elif header == "RecurringCharges":
-                    if len(aws_data["RecurringCharges"]) == 0:
-                        row.append("")
-                    elif "Amount" in aws_data["RecurringCharges"][0]:
-                        row.append(aws_data["RecurringCharges"][0]["Amount"])
-                    elif (
-                        "RecurringChargeAmount"
-                        in aws_data["RecurringCharges"][0]
-                    ):
-                        row.append(
-                            aws_data["RecurringCharges"][0][
-                                "RecurringChargeAmount"
-                            ]
+                )
+                for aws_data in reservation_data[aws_region][data_type][
+                    aws_service
+                ]:
+                    headers = ["AwsRegion"]
+                    headers.extend(
+                        list(
+                            reservation_data[aws_region][data_type][
+                                aws_service
+                            ][0].keys()
                         )
-                    else:
-                        row.append("")
-                elif isinstance(aws_data[header], (dict, list)):
-                    row.append(json.dumps(aws_data[header]))
-                else:
-                    row.append(aws_data[header])
-            rows.append(row)
-        sheets.append(
-            {
-                "sheet_name": "{}_{}".format(
-                    aws_service.lower(), kwargs["type"]
-                ),
-                "headers": headers,
-                "rows": rows,
-            }
-        )
+                    )
+                    row = []
+                    for header in headers:
+                        if header == "AwsRegion":
+                            row.append(aws_region)
+                        elif header not in aws_data:
+                            row.append("")
+                        elif isinstance(
+                            aws_data[header], datetime.datetime
+                        ):  # Google Sheets-friendly dates
+                            row.append(
+                                convert_to_gsheets_friendly_date(
+                                    aws_data[header]
+                                )
+                            )
+                        elif header == "RecurringCharges":
+                            if len(aws_data["RecurringCharges"]) == 0:
+                                row.append("")
+                            elif "Amount" in aws_data["RecurringCharges"][0]:
+                                row.append(
+                                    aws_data["RecurringCharges"][0]["Amount"]
+                                )
+                            elif (
+                                "RecurringChargeAmount"
+                                in aws_data["RecurringCharges"][0]
+                            ):
+                                row.append(
+                                    aws_data["RecurringCharges"][0][
+                                        "RecurringChargeAmount"
+                                    ]
+                                )
+                            else:
+                                row.append("")
+                        elif isinstance(aws_data[header], (dict, list)):
+                            row.append(json.dumps(aws_data[header]))
+                        else:
+                            row.append(aws_data[header])
+                    rows.append(row)
+            sheets.append(
+                {
+                    "sheet_name": "{}_{}".format(
+                        aws_service.lower(), data_type
+                    ),
+                    "headers": headers,
+                    "rows": rows,
+                }
+            )
     return sheets
 
 
@@ -77,19 +105,14 @@ def load_config():
 
 def main():
     config = load_config()
-    reservation_data = get_my_reservation_data()
+
+    # Get raw data for all enabled regions
+    reservation_data = {}
+    for aws_region in config["aws"]["regions"]:
+        reservation_data[aws_region] = get_my_reservation_data(aws_region)
 
     # Process raw data into sheets
-    sheets = []
-    sheets = process_aws_data(
-        type="my_reservations", raw_data=reservation_data["my_reservations"],
-    )
-    sheets.extend(
-        process_aws_data(
-            type="reservation_offerings",
-            raw_data=reservation_data["reservation_offerings"],
-        )
-    )
+    sheets = process_aws_data(reservation_data)
 
     # Update Google Sheets
     google_sheet = GoogleSheet(config["google_sheets"]["sheet_name"])

--- a/exporter/gsheets.py
+++ b/exporter/gsheets.py
@@ -62,7 +62,7 @@ class GoogleSheet:
         )
         for cell in cell_list:
             if (
-                len(cell_data) > cell.row
+                len(cell_data) >= cell.row
                 and len(cell_data[cell.row - 1]) >= cell.col
             ):
                 cell.value = cell_data[cell.row - 1][cell.col - 1]

--- a/exporter/gsheets.py
+++ b/exporter/gsheets.py
@@ -61,7 +61,13 @@ class GoogleSheet:
             build_range(2, column_count, row_count)
         )
         for cell in cell_list:
-            cell.value = cell_data[cell.row - 1][cell.col - 1]
+            if (
+                len(cell_data) > cell.row
+                and len(cell_data[cell.row - 1]) > cell.col
+            ):
+                cell.value = cell_data[cell.row - 1][cell.col - 1]
+            else:
+                cell.value = ""
         return cell_list
 
     def update_cells(self, cell_data):

--- a/exporter/gsheets.py
+++ b/exporter/gsheets.py
@@ -63,7 +63,7 @@ class GoogleSheet:
         for cell in cell_list:
             if (
                 len(cell_data) > cell.row
-                and len(cell_data[cell.row - 1]) > cell.col
+                and len(cell_data[cell.row - 1]) >= cell.col
             ):
                 cell.value = cell_data[cell.row - 1][cell.col - 1]
             else:


### PR DESCRIPTION
Adds a new `aws` section to the config yaml:

```
  aws:
    regions:
      - us-east-1
      - us-west-2
      - ap-northeast-1
      - eu-west-1
```

Also adds a new first column `AwsRegion` to each exported spreadsheet.