### PR TITLE
Add TagGroups feature for grouping EC2 & RDS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Exports AWS reservation data for a particular AWS account to a Google Sheet for 
 	| `google_sheets.sheet_name` | Name of the Google Sheet from the previous step | `String` |
 	| `aws.regions[]` | List of AWS regions to scrape data for | `List` |
 	| `aws.enabled_reports[]` | List of enabled reports. Supported options: `ec2`, `rds` | `List` |
-	| `aws.ec2_include_tags[]` | List of EC2 instance tags to scrape data for | `List` |
-	| `aws.rds_include_tags[]` | List of RDS instance tags to scrape data for | `List` |
+	| `aws.ec2_tag_groups[]` | List of EC2 instance tags to scrape data for | `List` |
+	| `aws.rds_tag_groups[]` | List of RDS instance tags to scrape data for | `List` |
 
 1. Commit your changes to the `master` branch and your `prod` environment will be deployed via GitHub Actions
 
@@ -101,7 +101,7 @@ Exports AWS reservation data for a particular AWS account to a Google Sheet for 
       - ec2
       - rds
 
-    ec2_include_tags:
+    ec2_tag_groups:
       - aws_region: us-east-1
         tag_name: Name
         tag_value: va-api--prod
@@ -109,7 +109,7 @@ Exports AWS reservation data for a particular AWS account to a Google Sheet for 
         tag_name: Name
         tag_value: or-api--prod
 
-    rds_include_tags:
+    rds_tag_groups:
       - aws_region: us-east-1
         tag_name: DBName
         tag_value: va-db--prod

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -13,6 +13,10 @@
       - ec2
       - rds
 
+#####
+# EC2
+#####
+
     ec2_tag_groups:
       - name: va-adserver
         aws_region: us-east-1
@@ -262,7 +266,63 @@
           - tag_name: Name
             tag_value: va-storm-universal-zookeeper
 
-    # rds_tag_groups:
-    #   - aws_region: us-east-1
-    #     tag_name: workload-type
-    #     tag_value: production
+#####
+# RDS
+#####
+
+    rds_tag_groups:
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-gumgum
+          - tag_name: Name
+            tag_value: va-test
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-bi
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: business-intelligence
+
+      - name: va-creative-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: creative-engineering
+
+      - name: va-databricks
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: databricks
+          - tag_name: Name
+            tag_value: databricksprod
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: druid-11
+          - tag_name: name
+            tag_value: va-superset-postgresql
+
+      - name: va-monitoring
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-monitoring-rds
+
+      - name: va-web-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: web-engineering
+          - tag_name: Name
+            tag_value: web-engineering-dev

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -13,24 +13,256 @@
       - ec2
       - rds
 
-    ec2_include_tags:
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: gumgum-databricks-prod-worker
-      - aws_region: us-west-2
-        tag_name: Name
-        tag_value: or-fluentd-universal-aggregator
-      - aws_region: ap-northeast-1
-        tag_name: Name
-        tag_value: jp-ad-server-adserving
-      - aws_region: eu-west-1
-        tag_name: Name
-        tag_value: ie-rtb-v3-schema-registry--prod
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: va-dsci--verity
+    ec2_tag_groups:
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-ad-server-adserving
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default
+          - tag_name: Name
+            tag_value: va-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: va-dynamodb-visitor-replication
 
-    rds_include_tags:
-      - aws_region: us-east-1
-        tag_name: workload-type
-        tag_value: production
+      - name: or-adserver
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-ad-server-adserving
+          - tag_name: Name
+            tag_value: or-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-default
+          - tag_name: Name
+            tag_value: or-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ssp
+          - tag_name: Name
+            tag_value: or-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: or-dynamodb-visitor-replication
+          - tag_name: Name
+            tag_value: or-aws-api-server
+
+      - name: jp-adserver
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-default
+          - tag_name: Name
+            tag_value: jp-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: jp-aws-api-server
+
+      - name: ie-adserver
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-default
+          - tag_name: Name
+            tag_value: ie-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: ie-aws-api-server
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-consul-server
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: consul-server
+
+      - name: va-cron
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-churro
+          - tag_name: Name
+            tag_value: va-cron-ad-server-mango
+          - tag_name: Name
+            tag_value: va-devtaco
+          - tag_name: Name
+            tag_value: va-taco
+          - tag_name: Name
+            tag_value: va-guacamole
+
+      - name: or-cron
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-donut
+
+      - name: jp-cron
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-sushi
+
+      - name: ie-cron
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-coddle
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-druid-0-11-broker
+          - tag_name: Name
+            tag_value: va-druid-0-11-coordinator
+          - tag_name: Name
+            tag_value: va-druid-0-11-overlord
+          - tag_name: Name
+            tag_value: va-druid-0-11-middleManager
+          - tag_name: Name
+            tag_value: va-druid-bi-0-11-broker-00
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-cold
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-hot
+          - tag_name: Name
+            tag_value: zookeeper-va-druid-0-11
+
+      - name: va-dsci
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-dsci-http--prod
+          - tag_name: Name
+            tag_value: va-kafka-monitoring-dsci
+
+      - name: va-emr
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-emr-forecasting-cluster
+
+      - name: va-fluentd
+        aws_region: us-east-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-universal-aggregator  
+
+      - name: or-fluentd
+        aws_region: us-west-2
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-universal-aggregator
+
+      - name: jp-fluentd
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-universal-aggregator
+
+      - name: ie-fluentd
+        aws_region: eu-west-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-universal-aggregator
+
+      - name: va-jenkins
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-jenkins-ci-ad-server
+          - tag_name: Name
+            tag_value: va-jenkins
+          - tag_name: Name
+            tag_value: va-jenkins-ci-web-engineering
+          - tag_name: Name
+            tag_value: va-jenkins-ci-croissant
+
+      - name: va-kafka
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-rtb-v3-kafka--prod
+          - tag_name: Name
+            tag_value: va-universal-v3-kafka--prod
+          - tag_name: Name
+            tag_value: kafka-confluent-rtb-v3-zookeeper
+          - tag_name: Name
+            tag_value: kafka-confluent-universal-v3-zookeeper
+      
+      - name: or-kafka
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-rtb-v3-schema-registry--prod
+
+      - name: ie-kafka
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-rtb-v3-schema-registry--prod     
+
+      - name: va-storm
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-taskrunner-wg1
+          - tag_name: Name
+            tag_value: va-taskrunner-wg2
+
+      - name: va-taskrunner
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-storm-universal-zookeeper
+
+    # rds_tag_groups:
+    #   - aws_region: us-east-1
+    #     tag_name: workload-type
+    #     tag_value: production

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -305,6 +305,12 @@
           - tag_name: Name
             tag_value: databricksprod
 
+      - name: va-drone
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: drone-cluster
+
       - name: va-druid
         aws_region: us-east-1
         tags:

--- a/config/test.yml
+++ b/config/test.yml
@@ -11,26 +11,258 @@
 
     enabled_reports:
       - ec2
-      - rds
+      # - rds
 
-    ec2_include_tags:
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: gumgum-databricks-prod-worker
-      - aws_region: us-west-2
-        tag_name: Name
-        tag_value: or-fluentd-universal-aggregator
-      - aws_region: ap-northeast-1
-        tag_name: Name
-        tag_value: jp-ad-server-adserving
-      - aws_region: eu-west-1
-        tag_name: Name
-        tag_value: ie-rtb-v3-schema-registry--prod
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: va-dsci--verity
+    ec2_tag_groups:
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-ad-server-adserving
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default
+          - tag_name: Name
+            tag_value: va-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: va-dynamodb-visitor-replication
 
-    rds_include_tags:
-      - aws_region: us-east-1
-        tag_name: workload-type
-        tag_value: production
+      - name: or-adserver
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-ad-server-adserving
+          - tag_name: Name
+            tag_value: or-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-default
+          - tag_name: Name
+            tag_value: or-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ssp
+          - tag_name: Name
+            tag_value: or-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: or-dynamodb-visitor-replication
+          - tag_name: Name
+            tag_value: or-aws-api-server
+
+      - name: jp-adserver
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-default
+          - tag_name: Name
+            tag_value: jp-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: jp-aws-api-server
+
+      - name: ie-adserver
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-default
+          - tag_name: Name
+            tag_value: ie-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: ie-aws-api-server
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-consul-server
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: consul-server
+
+      - name: va-cron
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-churro
+          - tag_name: Name
+            tag_value: va-cron-ad-server-mango
+          - tag_name: Name
+            tag_value: va-devtaco
+          - tag_name: Name
+            tag_value: va-taco
+          - tag_name: Name
+            tag_value: va-guacamole
+
+      - name: or-cron
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-donut
+
+      - name: jp-cron
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-sushi
+
+      - name: ie-cron
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-coddle
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-druid-0-11-broker
+          - tag_name: Name
+            tag_value: va-druid-0-11-coordinator
+          - tag_name: Name
+            tag_value: va-druid-0-11-overlord
+          - tag_name: Name
+            tag_value: va-druid-0-11-middleManager
+          - tag_name: Name
+            tag_value: va-druid-bi-0-11-broker-00
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-cold
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-hot
+          - tag_name: Name
+            tag_value: zookeeper-va-druid-0-11
+
+      - name: va-dsci
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-dsci-http--prod
+          - tag_name: Name
+            tag_value: va-kafka-monitoring-dsci
+
+      - name: va-emr
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-emr-forecasting-cluster
+
+      - name: va-fluentd
+        aws_region: us-east-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-universal-aggregator  
+
+      - name: or-fluentd
+        aws_region: us-west-2
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-universal-aggregator
+
+      - name: jp-fluentd
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-universal-aggregator
+
+      - name: ie-fluentd
+        aws_region: eu-west-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-universal-aggregator
+
+      - name: va-jenkins
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-jenkins-ci-ad-server
+          - tag_name: Name
+            tag_value: va-jenkins
+          - tag_name: Name
+            tag_value: va-jenkins-ci-web-engineering
+          - tag_name: Name
+            tag_value: va-jenkins-ci-croissant
+
+      - name: va-kafka
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-rtb-v3-kafka--prod
+          - tag_name: Name
+            tag_value: va-universal-v3-kafka--prod
+          - tag_name: Name
+            tag_value: kafka-confluent-rtb-v3-zookeeper
+          - tag_name: Name
+            tag_value: kafka-confluent-universal-v3-zookeeper
+      
+      - name: or-kafka
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-rtb-v3-schema-registry--prod
+
+      - name: ie-kafka
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-rtb-v3-schema-registry--prod     
+
+      - name: va-storm
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-taskrunner-wg1
+          - tag_name: Name
+            tag_value: va-taskrunner-wg2
+
+      - name: va-taskrunner
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-storm-universal-zookeeper
+
+    # rds_tag_groups:
+    #   - aws_region: us-east-1
+    #     tag_name: workload-type
+    #     tag_value: production

--- a/config/test.yml
+++ b/config/test.yml
@@ -11,7 +11,11 @@
 
     enabled_reports:
       - ec2
-      # - rds
+      - rds
+
+#####
+# EC2
+#####
 
     ec2_tag_groups:
       - name: va-adserver
@@ -262,7 +266,63 @@
           - tag_name: Name
             tag_value: va-storm-universal-zookeeper
 
-    # rds_tag_groups:
-    #   - aws_region: us-east-1
-    #     tag_name: workload-type
-    #     tag_value: production
+#####
+# RDS
+#####
+
+    rds_tag_groups:
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-gumgum
+          - tag_name: Name
+            tag_value: va-test
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-bi
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: business-intelligence
+
+      - name: va-creative-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: creative-engineering
+
+      - name: va-databricks
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: databricks
+          - tag_name: Name
+            tag_value: databricksprod
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: druid-11
+          - tag_name: name
+            tag_value: va-superset-postgresql
+
+      - name: va-monitoring
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-monitoring-rds
+
+      - name: va-web-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: web-engineering
+          - tag_name: Name
+            tag_value: web-engineering-dev

--- a/config/test.yml
+++ b/config/test.yml
@@ -305,6 +305,12 @@
           - tag_name: Name
             tag_value: databricksprod
 
+      - name: va-drone
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: drone-cluster
+
       - name: va-druid
         aws_region: us-east-1
         tags:

--- a/exporter/aws.py
+++ b/exporter/aws.py
@@ -47,6 +47,14 @@ def get_my_reservation_data(aws_region, enabled_reports):
 
 
 def get_my_ec2_instances(aws_region, tag_name, tag_value):
+    print(
+        (
+            "Looking up EC2 instances in {region} with tag "
+            "key {key} and tag value {value}.."
+        ).format(
+            region=aws_region, key=tag_name, value=tag_value,
+        )
+    )
     ec2_client = boto3.client("ec2", aws_region)
     ec2_instances_all_running = ec2_client.describe_instances(
         Filters=[
@@ -65,6 +73,14 @@ def get_my_ec2_instances(aws_region, tag_name, tag_value):
 
 
 def get_my_rds_instances(aws_region, tag_name, tag_value):
+    print(
+        (
+            "Looking up RDS instances in {region} with tag "
+            "key {key} and tag value {value}.."
+        ).format(
+            region=aws_region, key=tag_name, value=tag_value,
+        )
+    )
     rds_client = boto3.client("rds", aws_region)
     rds_instances = rds_client.describe_db_instances()
     filtered_rds_instances = []
@@ -94,12 +110,16 @@ def get_my_tagged_resources(**kwargs):
                     tag["tags"][0]["tag_value"],
                 )
         if enabled_service == "rds":
-            for tag in kwargs["rds_tag_groups"]:
-                tagged_resources[enabled_service][
-                    tag["name"]
-                ] = get_my_rds_instances(
-                    kwargs["aws_region"],
-                    tag["tags"][0]["tag_name"],
-                    tag["tags"][0]["tag_value"],
-                )
+            for tag_group in kwargs["rds_tag_groups"]:
+                tagged_resources[enabled_service][tag_group["name"]] = []
+                for tag in tag_group["tags"]:
+                    tagged_resources[enabled_service][
+                        tag_group["name"]
+                    ].extend(
+                        get_my_rds_instances(
+                            kwargs["aws_region"],
+                            tag["tag_name"],
+                            tag["tag_value"],
+                        )
+                    )
     return tagged_resources

--- a/exporter/aws.py
+++ b/exporter/aws.py
@@ -82,23 +82,24 @@ def get_my_tagged_resources(**kwargs):
     tagged_resources = {}
     for enabled_service in kwargs["enabled_services"]:
         if enabled_service not in tagged_resources:
-            tagged_resources[enabled_service] = []
+            tagged_resources[enabled_service] = {}
         if enabled_service == "ec2":
-            for tag in kwargs["ec2_include_tags"]:
-                tagged_resources[enabled_service].extend(
-                    get_my_ec2_instances(
-                        kwargs["aws_region"],
-                        tag["tag_name"],
-                        tag["tag_value"],
-                    )
+            # TODO: support multiple tags per resource (using AND/OR logic)
+            for tag in kwargs["ec2_tag_groups"]:
+                tagged_resources[enabled_service][
+                    tag["name"]
+                ] = get_my_ec2_instances(
+                    kwargs["aws_region"],
+                    tag["tags"][0]["tag_name"],
+                    tag["tags"][0]["tag_value"],
                 )
         if enabled_service == "rds":
-            for tag in kwargs["rds_include_tags"]:
-                tagged_resources[enabled_service].extend(
-                    get_my_rds_instances(
-                        kwargs["aws_region"],
-                        tag["tag_name"],
-                        tag["tag_value"],
-                    )
+            for tag in kwargs["rds_tag_groups"]:
+                tagged_resources[enabled_service][
+                    tag["name"]
+                ] = get_my_rds_instances(
+                    kwargs["aws_region"],
+                    tag["tags"][0]["tag_name"],
+                    tag["tags"][0]["tag_value"],
                 )
     return tagged_resources

--- a/exporter/config.yml
+++ b/exporter/config.yml
@@ -11,7 +11,11 @@
 
     enabled_reports:
       - ec2
-      # - rds
+      - rds
+
+#####
+# EC2
+#####
 
     ec2_tag_groups:
       - name: va-adserver
@@ -262,7 +266,63 @@
           - tag_name: Name
             tag_value: va-storm-universal-zookeeper
 
+#####
+# RDS
+#####
+
     rds_tag_groups:
-    #   - aws_region: us-east-1
-    #     tag_name: workload-type
-    #     tag_value: production
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-gumgum
+          - tag_name: Name
+            tag_value: va-test
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-bi
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: business-intelligence
+
+      - name: va-creative-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: creative-engineering
+
+      - name: va-databricks
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: databricks
+          - tag_name: Name
+            tag_value: databricksprod
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: druid-11
+          - tag_name: name
+            tag_value: va-superset-postgresql
+
+      - name: va-monitoring
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-monitoring-rds
+
+      - name: va-web-engineering
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: web-engineering
+          - tag_name: Name
+            tag_value: web-engineering-dev

--- a/exporter/config.yml
+++ b/exporter/config.yml
@@ -305,6 +305,12 @@
           - tag_name: Name
             tag_value: databricksprod
 
+      - name: va-drone
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: drone-cluster
+
       - name: va-druid
         aws_region: us-east-1
         tags:

--- a/exporter/config.yml
+++ b/exporter/config.yml
@@ -1,7 +1,7 @@
 --- 
   google_sheets:
     sheet_name: Reserved Instances Analyzer
-  
+
   aws:
     regions:
       - us-east-1
@@ -11,26 +11,258 @@
 
     enabled_reports:
       - ec2
-      - rds
+      # - rds
 
-    ec2_include_tags:
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: gumgum-databricks-prod-worker
-      - aws_region: us-west-2
-        tag_name: Name
-        tag_value: or-fluentd-universal-aggregator
-      - aws_region: ap-northeast-1
-        tag_name: Name
-        tag_value: jp-ad-server-adserving
-      - aws_region: eu-west-1
-        tag_name: Name
-        tag_value: ie-rtb-v3-schema-registry--prod
-      - aws_region: us-east-1
-        tag_name: Name
-        tag_value: va-dsci--verity
+    ec2_tag_groups:
+      - name: va-adserver
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-ad-server-adserving
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-adserving-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default
+          - tag_name: Name
+            tag_value: va-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-default-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ssp-test-new-relic
+          - tag_name: Name
+            tag_value: va-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: va-dynamodb-visitor-replication
 
-    rds_include_tags:
-      - aws_region: us-east-1
-        tag_name: workload-type
-        tag_value: production
+      - name: or-adserver
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-ad-server-adserving
+          - tag_name: Name
+            tag_value: or-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-default
+          - tag_name: Name
+            tag_value: or-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ssp
+          - tag_name: Name
+            tag_value: or-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: or-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: or-dynamodb-visitor-replication
+          - tag_name: Name
+            tag_value: or-aws-api-server
+
+      - name: jp-adserver
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving
+          - tag_name: Name
+            tag_value: jp-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-default
+          - tag_name: Name
+            tag_value: jp-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp
+          - tag_name: Name
+            tag_value: jp-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: jp-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: jp-aws-api-server
+
+      - name: ie-adserver
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving
+          - tag_name: Name
+            tag_value: ie-ad-server-adserving-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-default
+          - tag_name: Name
+            tag_value: ie-ad-server-default-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp
+          - tag_name: Name
+            tag_value: ie-ad-server-ssp-new-relic
+          - tag_name: Name
+            tag_value: ie-ad-server-ecs--prod
+          - tag_name: Name
+            tag_value: ie-aws-api-server
+
+      - name: va-astronomer
+        aws_region: us-east-1
+        tags:
+          - tag_name: Billing
+            tag_value: astronomer-airflow-poc
+
+      - name: va-consul-server
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: consul-server
+
+      - name: va-cron
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-churro
+          - tag_name: Name
+            tag_value: va-cron-ad-server-mango
+          - tag_name: Name
+            tag_value: va-devtaco
+          - tag_name: Name
+            tag_value: va-taco
+          - tag_name: Name
+            tag_value: va-guacamole
+
+      - name: or-cron
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-donut
+
+      - name: jp-cron
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: Name
+            tag_value: jp-sushi
+
+      - name: ie-cron
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-coddle
+
+      - name: va-druid
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-druid-0-11-broker
+          - tag_name: Name
+            tag_value: va-druid-0-11-coordinator
+          - tag_name: Name
+            tag_value: va-druid-0-11-overlord
+          - tag_name: Name
+            tag_value: va-druid-0-11-middleManager
+          - tag_name: Name
+            tag_value: va-druid-bi-0-11-broker-00
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-cold
+          - tag_name: Name
+            tag_value: va-druid-0-11-historical-hot
+          - tag_name: Name
+            tag_value: zookeeper-va-druid-0-11
+
+      - name: va-dsci
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-dsci-http--prod
+          - tag_name: Name
+            tag_value: va-kafka-monitoring-dsci
+
+      - name: va-emr
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-emr-forecasting-cluster
+
+      - name: va-fluentd
+        aws_region: us-east-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: va-fluentd-universal-aggregator  
+
+      - name: or-fluentd
+        aws_region: us-west-2
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: or-fluentd-universal-aggregator
+
+      - name: jp-fluentd
+        aws_region: ap-northeast-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: jp-fluentd-universal-aggregator
+
+      - name: ie-fluentd
+        aws_region: eu-west-1
+        tags:
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-slot-aggregator
+          - tag_name: AnsibleClusterId
+            tag_value: ie-fluentd-universal-aggregator
+
+      - name: va-jenkins
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-jenkins-ci-ad-server
+          - tag_name: Name
+            tag_value: va-jenkins
+          - tag_name: Name
+            tag_value: va-jenkins-ci-web-engineering
+          - tag_name: Name
+            tag_value: va-jenkins-ci-croissant
+
+      - name: va-kafka
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-rtb-v3-kafka--prod
+          - tag_name: Name
+            tag_value: va-universal-v3-kafka--prod
+          - tag_name: Name
+            tag_value: kafka-confluent-rtb-v3-zookeeper
+          - tag_name: Name
+            tag_value: kafka-confluent-universal-v3-zookeeper
+      
+      - name: or-kafka
+        aws_region: us-west-2
+        tags:
+          - tag_name: Name
+            tag_value: or-rtb-v3-schema-registry--prod
+
+      - name: ie-kafka
+        aws_region: eu-west-1
+        tags:
+          - tag_name: Name
+            tag_value: ie-rtb-v3-schema-registry--prod     
+
+      - name: va-storm
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-taskrunner-wg1
+          - tag_name: Name
+            tag_value: va-taskrunner-wg2
+
+      - name: va-taskrunner
+        aws_region: us-east-1
+        tags:
+          - tag_name: Name
+            tag_value: va-storm-universal-zookeeper
+
+    rds_tag_groups:
+    #   - aws_region: us-east-1
+    #     tag_name: workload-type
+    #     tag_value: production

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -20,6 +20,53 @@ from gsheets import (
 )
 
 
+def get_resource_instance_class(aws_service, resource):
+    if aws_service == "ec2":
+        return resource["InstanceType"].split(".")[0]
+    elif aws_service == "rds":
+        return "db.{}".format(resource["DBInstanceClass"].split(".")[1])
+    else:
+        raise Exception("Unexpected aws_service {}".format(aws_service))
+
+
+def get_resource_normalized_capacity(aws_service, resource):
+    size_to_normalized = {
+        "nano": 0.25,
+        "micro": 0.5,
+        "small": 1,
+        "medium": 2,
+        "large": 4,
+        "xlarge": 8,
+        "2xlarge": 16,
+        "3xlarge": 24,
+        "4xlarge": 32,
+        "6xlarge": 48,
+        "8xlarge": 64,
+        "9xlarge": 72,
+        "10xlarge": 80,
+        "12xlarge": 96,
+        "16xlarge": 128,
+        "18xlarge": 144,
+        "24xlarge": 192,
+        "32xlarge": 256,
+    }
+    if aws_service == "ec2":
+        ec2_size = resource["InstanceType"].split(".")[1]
+        if ec2_size in size_to_normalized:
+            return size_to_normalized[ec2_size]
+        else:
+            return ""
+    elif aws_service == "rds":
+        rds_size = resource["DBInstanceClass"].split(".")[2]
+        rds_multi_az = resource["MultiAZ"]
+        rds_size_normalized = size_to_normalized[rds_size]
+        if rds_multi_az:
+            rds_size_normalized = rds_size_normalized * 2
+        return rds_size_normalized
+    else:
+        raise Exception("Unexpected aws_service {}".format(aws_service))
+
+
 def process_aws_reservation_data(reservation_data):
     first_region = list(reservation_data.keys())[0]
     data_enabled = list(reservation_data[first_region].keys())
@@ -29,7 +76,7 @@ def process_aws_reservation_data(reservation_data):
     sheets = []
     for aws_service in services_enabled:
         for data_type in data_enabled:
-            headers = ["AwsRegion"]
+            headers = ["AwsRegion", "InstanceClass", "NormalizedCapacity"]
             headers.extend(
                 list(
                     reservation_data[list(reservation_data.keys())[0]][
@@ -54,6 +101,18 @@ def process_aws_reservation_data(reservation_data):
                     for header in headers:
                         if header == "AwsRegion":
                             row.append(aws_region)
+                        elif header == "InstanceClass":
+                            row.append(
+                                get_resource_instance_class(
+                                    aws_service, aws_data
+                                )
+                            )
+                        elif header == "NormalizedCapacity":
+                            row.append(
+                                get_resource_normalized_capacity(
+                                    aws_service, aws_data
+                                )
+                            )
                         elif header not in aws_data:
                             row.append("")
                         elif isinstance(
@@ -104,7 +163,12 @@ def process_aws_tagged_resources(tagged_resources):
     services_enabled = list(tagged_resources[first_region].keys())
     sheets = []
     for aws_service in services_enabled:
-        headers = ["TagGroup", "AwsRegion"]
+        headers = [
+            "TagGroup",
+            "AwsRegion",
+            "InstanceClass",
+            "NormalizedCapacity",
+        ]
         rows = []
         for aws_region in tagged_resources:
             print(
@@ -124,7 +188,7 @@ def process_aws_tagged_resources(tagged_resources):
                     for resource in tagged_resources[aws_region][aws_service][
                         tag_group_name
                     ]:
-                        if len(headers) == 2:
+                        if len(headers) == 4:
                             headers.extend(list(resource.keys()))
                         row = []
                         for header in headers:
@@ -132,6 +196,18 @@ def process_aws_tagged_resources(tagged_resources):
                                 row.append(tag_group_name)
                             elif header == "AwsRegion":
                                 row.append(aws_region)
+                            elif header == "InstanceClass":
+                                row.append(
+                                    get_resource_instance_class(
+                                        aws_service, resource
+                                    )
+                                )
+                            elif header == "NormalizedCapacity":
+                                row.append(
+                                    get_resource_normalized_capacity(
+                                        aws_service, resource
+                                    )
+                                )
                             elif header not in resource:
                                 row.append("")
                             elif header == "Tags":

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -21,9 +21,6 @@ from gsheets import (
 
 
 def get_resource_instance_class(aws_service, resource):
-    # if "InstanceCount" in
-    #                             "DBInstanceCount"
-
     if aws_service == "ec2":
         return resource["InstanceType"].split(".")[0]
     elif aws_service == "rds":

--- a/terraform/modules/lambda-exporter/lambda.tf
+++ b/terraform/modules/lambda-exporter/lambda.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   runtime          = "python3.6"
   memory_size      = "256"
-  timeout          = "120"
+  timeout          = "300"
 
   environment {
     variables = {


### PR DESCRIPTION
- Add `TagGroup`, `InstanceClass` & `NormalizedCapacity` columns to EC2 and RDS usage reports
- Add new columns `NormalizedCapacity` and `NormalizedCapacityTotal` to reservation reports
- Improve logging when retrieving EC2 and RDS instance data