### PR TITLE
Cache EC2 & RDS instance lists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       uses: mechtron/amazon-reservation-exporter/set-env-action@0.2.0
     - name: Run Terragrunt
       id: run_terragrunt
-      uses: mechtron/amazon-reservation-exporter/terragrunt-action@0.6.0
+      uses: mechtron/amazon-reservation-exporter/terragrunt-action@cache-ec2-rds-instances
       with:
         env: ${{ steps.set_env.outputs.env }}
         tf_action: apply

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .terraform
 .terragrunt-cache
 
+.vscode
+
 exporter/__pycache__
 exporter/venv
 exporter/bin

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -124,7 +124,7 @@
         aws_region: us-east-1
         tags:
           - tag_name: Billing
-            tag_value: astronomer-airflow-poc
+            tag_value: astronomer-airflow
 
       - name: va-consul
         aws_region: us-east-1
@@ -360,7 +360,7 @@
         aws_region: us-east-1
         tags:
           - tag_name: Billing
-            tag_value: astronomer-airflow-poc
+            tag_value: astronomer-airflow
 
       - name: va-bi
         aws_region: us-east-1

--- a/config/test.yml
+++ b/config/test.yml
@@ -124,7 +124,7 @@
         aws_region: us-east-1
         tags:
           - tag_name: Billing
-            tag_value: astronomer-airflow-poc
+            tag_value: astronomer-airflow
 
       - name: va-consul
         aws_region: us-east-1
@@ -360,7 +360,7 @@
         aws_region: us-east-1
         tags:
           - tag_name: Billing
-            tag_value: astronomer-airflow-poc
+            tag_value: astronomer-airflow
 
       - name: va-bi
         aws_region: us-east-1

--- a/terragrunt-action/Dockerfile
+++ b/terragrunt-action/Dockerfile
@@ -4,8 +4,13 @@ LABEL mechtron <mechtrondev@gmail.com>
 ENV TERRAFORM_VERSION=0.12.17
 ENV TERRAGRUNT_VERSION=0.21.6
 
-RUN apk -v --update add go python3 py-pip alpine-sdk coreutils terraform=$TERRAFORM_VERSION-r0
+RUN apk -v --update add go python3 py-pip alpine-sdk coreutils
 RUN pip install --upgrade awscli
+
+ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip /
+RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    mv terraform /usr/local/bin/ && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 ADD https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_386 /bin/terragrunt
 RUN chmod +x /bin/terragrunt


### PR DESCRIPTION
Problem: for every tag in an RDS `TagGroup`, we would perform a `ListTagsForResource` API call per RDS resource discovered. This is way too many repetitive API calls!

Solution: look-up EC2/RDS instances once and pass the cached list to required functions